### PR TITLE
Fund wallets using aync transactions.

### DIFF
--- a/faucet/core/models.py
+++ b/faucet/core/models.py
@@ -45,7 +45,7 @@ class Faucet(models.Model):
         # but the API accepts only whole integers
         quantity = int(self.sending_amount * (10 ** balance["exponent"]))
         fee = int(self.fee * (10 ** balance["exponent"]))
-        return wallet.transactions.create(settings.UPVEST_PASSWORD, str(self.asset_id), quantity, fee, receive_address)
+        return wallet.transactions.create(settings.UPVEST_PASSWORD, str(self.asset_id), quantity, fee, receive_address, asynchronous=True)
 
     def get_balance(self, wallet):
         for bal in wallet.balances:

--- a/faucet/core/templates/faucet.html
+++ b/faucet/core/templates/faucet.html
@@ -60,10 +60,10 @@
           {% if tx %}
           <div class="row mt-5">
             <div class="col-md-8 alert alert-primary">
-              Success! {{ faucet.sending_amount.normalize }} {{ faucet.asset_code }} has been sent to {{ address }}.
-              Transaction is
-              <a href='https://ropsten.etherscan.io/tx/{{ tx.txhash }}'>
-                {{ tx.txhash }}
+              Success! {{ faucet.sending_amount.normalize }} {{ faucet.asset_code }} has been sent to your address.
+              View your transactions here
+              <a href='https://ropsten.etherscan.io/address/{{ address }}'>
+                {{ address }}
               </a>
             </div>
           </div>

--- a/faucet/core/views.py
+++ b/faucet/core/views.py
@@ -118,7 +118,7 @@ class FaucetView(View):
                 return JsonResponse(
                     {
                         "message": "Request received successfully. %s will be sent to %s" % (amount, address),
-                        "tx": tx.txhash,
+                        "tx": tx.id,
                     },
                     status=200,
                 )


### PR DESCRIPTION
This PR switches the faucet to make `async` transactions against the Upvest API. This is because synchronous transaction creation is very slow and in danger of timing out. The PR also forces transactions to be async by default.

The `txhash` is no longer synchronously returned during the funding call. Instead the Upvest internal transaction id is returned.